### PR TITLE
Image operations

### DIFF
--- a/src/AIgnite/data/docset.py
+++ b/src/AIgnite/data/docset.py
@@ -26,6 +26,7 @@ class FigureChunk(BaseChunk):
     type: Literal[ChunkType.FIGURE]
     image_path: str | None  # e.g. local path, S3 url
     alt_text: Optional[str] = None
+    image_data: Optional[bytes] = None
 
 
 class TableChunk(BaseChunk):

--- a/test/index/paper_indexer_testbed.py
+++ b/test/index/paper_indexer_testbed.py
@@ -14,10 +14,12 @@ from AIgnite.index.paper_indexer import PaperIndexer
 from AIgnite.data.docset import DocSet, TextChunk, FigureChunk, TableChunk, ChunkType
 from AIgnite.db.metadata_db import MetadataDB, Base
 from AIgnite.db.vector_db import VectorDB
+from AIgnite.db.image_db import MinioImageDB
 from sqlalchemy import create_engine, text
 from PIL import Image
 from typing import Dict, Any, Tuple, List, Optional
 import os
+import sys
 import unittest
 from pathlib import Path
 
@@ -50,6 +52,7 @@ class PaperIndexerTestBed(TestBed):
     - 博客功能测试
     - 过滤功能测试
     - 全文存储和检索测试
+    - 图像存储和批量删除测试
     """
     
     def __init__(self, config_path: str):
@@ -171,7 +174,10 @@ class PaperIndexerTestBed(TestBed):
                     TextChunk(id="chunk8", type=ChunkType.TEXT, text="Few-shot and zero-shot prompting strategies."),
                     TextChunk(id="chunk9", type=ChunkType.TEXT, text="Evaluation of prompt effectiveness.")
                 ],
-                figure_chunks=[],
+                figure_chunks=[
+                    FigureChunk(id="fig4", type=ChunkType.FIGURE, image_path=self.test_images["fig4"], alt_text="Prompt engineering"),
+                    FigureChunk(id="fig5", type=ChunkType.FIGURE, image_path=self.test_images["fig5"], alt_text="Prompt engineering")
+                ],
                 table_chunks=[],
                 metadata={},
                 pdf_path=self.test_pdfs["pdf3"],
@@ -190,7 +196,10 @@ class PaperIndexerTestBed(TestBed):
                     TextChunk(id="chunk11", type=ChunkType.TEXT, text="Transfer learning in computer vision."),
                     TextChunk(id="chunk12", type=ChunkType.TEXT, text="Real-world applications of CNNs.")
                 ],
-                figure_chunks=[],
+                figure_chunks=[
+                    FigureChunk(id="fig6", type=ChunkType.FIGURE, image_path=self.test_images["fig6"], alt_text="CNN architecture"),
+                    FigureChunk(id="fig7", type=ChunkType.FIGURE, image_path=self.test_images["fig7"], alt_text="Training results")
+                ],
                 table_chunks=[],
                 metadata={},
                 pdf_path=self.test_pdfs["pdf4"],
@@ -209,10 +218,35 @@ class PaperIndexerTestBed(TestBed):
                     TextChunk(id="chunk14", type=ChunkType.TEXT, text="Comparison with CNN-based approaches."),
                     TextChunk(id="chunk15", type=ChunkType.TEXT, text="Performance on image recognition benchmarks.")
                 ],
-                figure_chunks=[],
+                figure_chunks=[
+                    FigureChunk(id="fig8", type=ChunkType.FIGURE, image_path=self.test_images["fig8"], alt_text="Vision transformer architecture"),
+                    FigureChunk(id="fig9", type=ChunkType.FIGURE, image_path=self.test_images["fig9"], alt_text="Attention visualization")
+                ],
                 table_chunks=[],
                 metadata={},
                 pdf_path=self.test_pdfs["pdf5"],
+                HTML_path=None,
+                comments=None
+            ),
+            DocSet(
+                doc_id="2106.14839",
+                title="Deep Learning for Computer Vision Applications",
+                abstract="Comprehensive study of deep learning techniques applied to computer vision tasks including object detection, segmentation, and classification.",
+                authors=["Author 11", "Author 12"],
+                categories=["cs.CV", "cs.LG"],
+                published_date="2021-07-03",
+                text_chunks=[
+                    TextChunk(id="chunk16", type=ChunkType.TEXT, text="Deep learning architectures for computer vision tasks."),
+                    TextChunk(id="chunk17", type=ChunkType.TEXT, text="Object detection and segmentation techniques."),
+                    TextChunk(id="chunk18", type=ChunkType.TEXT, text="Performance evaluation and benchmarking methods.")
+                ],
+                figure_chunks=[
+                    FigureChunk(id="fig10", type=ChunkType.FIGURE, image_path=self.test_images["fig10"], alt_text="Deep learning architecture"),
+                    FigureChunk(id="fig11", type=ChunkType.FIGURE, image_path=self.test_images["fig11"], alt_text="Object detection results")
+                ],
+                table_chunks=[],
+                metadata={},
+                pdf_path=self.test_pdfs["pdf5"],  # 复用pdf5，因为只是测试
                 HTML_path=None,
                 comments=None
             )
@@ -259,14 +293,29 @@ class PaperIndexerTestBed(TestBed):
         self.metadata_db = MetadataDB(db_path=db_url)
         self.logger.info("Metadata database initialized")
         
+        # 初始化图片数据库
+        image_db_config = self.config.get('minio_db', {})
+        if image_db_config:
+            self.image_db = MinioImageDB(
+                endpoint=image_db_config.get('endpoint', 'localhost:9081'),
+                access_key=image_db_config.get('access_key', 'XOrv2wfoWfPypp2zGIae'),
+                secret_key=image_db_config.get('secret_key', 'k9agaJuX2ZidOtaBxdc9Q2Hz5GnNKncNBnEZIoK3'),
+                bucket_name=image_db_config.get('bucket_name', 'aignite-test-papers-test'),
+                secure=image_db_config.get('secure', False)
+            )
+            self.logger.info("Image database initialized")
+        else:
+            self.image_db = None
+            self.logger.warning("Image database configuration not found, skipping image database initialization")
+        
         # 初始化PaperIndexer
-        self.indexer = PaperIndexer(self.vector_db, self.metadata_db, None)
+        self.indexer = PaperIndexer(self.vector_db, self.metadata_db, self.image_db)
         self.logger.info("PaperIndexer initialized with real databases")
         
         # 索引测试数据
         self.logger.info("Indexing test papers...")
         
-        indexing_results = self.indexer.index_papers(data)
+        indexing_results = self.indexer.index_papers(data, store_images=True,keep_temp_image=True)
         
         # 检查索引结果
         for doc_id, status in indexing_results.items():
@@ -285,6 +334,7 @@ class PaperIndexerTestBed(TestBed):
         self.logger.info("Running PaperIndexer tests...")
         
         results = {
+            'test_index_papers': self._test_index_papers(),
             'vector_search': self._test_vector_search(),
             'tfidf_search': self._test_tfidf_search(),
             'hybrid_search': self._test_hybrid_search(),
@@ -294,7 +344,11 @@ class PaperIndexerTestBed(TestBed):
             'vector_search_with_exclusion_filter': self._test_vector_search_with_exclusion_filter(),
             'full_text_storage_and_retrieval': self._test_full_text_storage_and_retrieval(),
             'full_text_deletion': self._test_full_text_deletion(),
-            'full_text_integration_with_search': self._test_full_text_integration_with_search()
+            'full_text_integration_with_search': self._test_full_text_integration_with_search(),
+            'store_images': self._test_store_images(),
+            'list_images': self._test_list_images(),
+            'delete_images_by_doc_id': self._test_delete_images_by_doc_id(),
+            'store_duplicated_images': self._test_store_duplicated_images(),
         }
         
         # 统计测试结果
@@ -306,12 +360,15 @@ class PaperIndexerTestBed(TestBed):
         return results
     
     def _create_test_files(self) -> None:
+        print("\n" + "="*60)
+        print("🧪 TEST: _create_test_files - 创建测试文件")
+        print("="*60)
         """创建测试文件"""
         self.logger.info("Creating test images and PDFs...")
         
         # 创建测试图片
         
-        for i in range(5):
+        for i in range(11):  # 增加到11个图片，为2106.14838添加fig8和fig9，为2106.14839添加fig10和fig11
             image_path = os.path.join(self.temp_dir, f"test_image_{i}.png")
             img = Image.new('RGB', (100 + i*50, 100 + i*50), color=f'rgb({i*50}, {i*50}, {i*50})')
             img.save(image_path)
@@ -328,7 +385,87 @@ class PaperIndexerTestBed(TestBed):
         self.logger.info(f"Created {len(self.test_images)} test images and {len(self.test_pdfs)} test PDFs")
     
     # 具体的测试方法
+
+
+    def _test_index_papers(self) -> Dict[str, Any]:
+        print("\n" + "="*60)
+        print("🧪 TEST: _test_index_papers - 测试索引论文")
+        print("="*60)
+        """测试索引论文"""
+        try:
+            if self.image_db is None:
+                success = True  # Skip test if image database not available
+                details = "Image database not available - test skipped"
+                self.log_test_result("Index Papers", success, details)
+                return {'success': success, 'details': details}
+            
+            # 检查所有测试论文的图像存储状态
+            total_papers = len(self.test_papers)
+            papers_with_images = 0
+            total_images_stored = 0
+            storage_status_summary = {}
+            
+            print(f"📊 检查 {total_papers} 个测试论文的图像存储状态...")
+            
+            for paper in self.test_papers:
+                doc_id = paper.doc_id
+                if not paper.figure_chunks:
+                    continue
+                
+                papers_with_images += 1
+                expected_figure_ids = [chunk.id for chunk in paper.figure_chunks]
+                
+                # 获取存储状态
+                storage_status = self.indexer.get_image_storage_status_for_doc(doc_id)
+                print(f"📄 论文 {doc_id}: {len(expected_figure_ids)} 个图像")
+                print(f"   存储状态: {storage_status}")
+                
+                # 统计已存储的图像数量
+                stored_count = 0
+                for figure_id in expected_figure_ids:
+                    image_key = f"{doc_id}_{figure_id}"
+                    if storage_status.get(image_key, False):
+                        stored_count += 1
+                
+                total_images_stored += stored_count
+                storage_status_summary[doc_id] = {
+                    'expected': len(expected_figure_ids),
+                    'stored': stored_count,
+                    'status': storage_status
+                }
+                
+                print(f"   已存储: {stored_count}/{len(expected_figure_ids)} 个图像")
+            
+            # 验证存储结果
+            all_images_stored = total_images_stored > 0
+            expected_total_images = sum(len(paper.figure_chunks) for paper in self.test_papers if paper.figure_chunks)
+            storage_complete = total_images_stored == expected_total_images
+            
+            success = all_images_stored and storage_complete
+            details = f"Index papers image storage: {total_images_stored}/{expected_total_images} images stored across {papers_with_images} papers with images"
+            
+            if not success:
+                details += f". Storage status summary: {storage_status_summary}"
+            
+            self.log_test_result("Index Papers", success, details)
+            return {
+                'success': success, 
+                'total_papers': total_papers,
+                'papers_with_images': papers_with_images,
+                'total_images_stored': total_images_stored,
+                'expected_total_images': expected_total_images,
+                'storage_status_summary': storage_status_summary,
+                'details': details
+            }
+            
+        except Exception as e:
+            self.log_test_result("Index Papers", False, f"Error: {str(e)}")
+            return {'success': False, 'error': str(e)}
+        
     def _test_vector_search(self) -> Dict[str, Any]:
+        print("\n" + "="*60)
+        print("🧪 TEST: _test_vector_search - 测试向量搜索")
+        print("="*60)
         """测试向量搜索"""
         try:
             query = "large language models"
@@ -350,6 +487,9 @@ class PaperIndexerTestBed(TestBed):
             return {'success': False, 'error': str(e)}
     
     def _test_tfidf_search(self) -> Dict[str, Any]:
+        print("\n" + "="*60)
+        print("🧪 TEST: _test_tfidf_search - 测试TF-IDF搜索")
+        print("="*60)
         """测试TF-IDF搜索"""
         try:
             query = "BERT architecture"
@@ -371,6 +511,9 @@ class PaperIndexerTestBed(TestBed):
             return {'success': False, 'error': str(e)}
     
     def _test_hybrid_search(self) -> Dict[str, Any]:
+        print("\n" + "="*60)
+        print("🧪 TEST: _test_hybrid_search - 测试混合搜索")
+        print("="*60)
         """测试混合搜索"""
         try:
             query = "transformer models"
@@ -392,6 +535,9 @@ class PaperIndexerTestBed(TestBed):
             return {'success': False, 'error': str(e)}
     
     def _test_delete_paper(self) -> Dict[str, Any]:
+        print("\n" + "="*60)
+        print("🧪 TEST: _test_delete_paper - 测试删除论文")
+        print("="*60)
         """测试删除论文"""
         try:
             doc_id = "2106.14838"  # 删除最后一个论文
@@ -406,9 +552,35 @@ class PaperIndexerTestBed(TestBed):
                 print(result)
             doc_exists_before = any(result.get('doc_id') == doc_id for result in results_before)
             
+            # 检查删除前的图像存储状态
+            image_storage_before = {}
+            image_storage_before = self.indexer.get_image_storage_status_for_doc(doc_id)
+            print(f"Image storage status before deletion: {image_storage_before}")
+            assert image_storage_before is not None, "Image storage status before deletion is None"
+
+            
             # 执行删除
             delete_result = self.indexer.delete_paper(doc_id)
             success = all(delete_result.values())
+            print(f"Delete result: {delete_result}")
+            
+            # 验证图像删除
+            image_deletion_success = True
+            if image_storage_before and self.indexer.image_db is not None:
+                # 检查MinIO中是否还有相关图像
+                for image_id, was_stored in image_storage_before.items():
+                    if was_stored:
+                        try:
+                            # 尝试获取图像，如果返回None说明已删除
+                            image_data = self.indexer.image_db.get_image(image_id)
+                            if image_data is not None:
+                                print(f"Warning: Image {image_id} still exists in MinIO after deletion")
+                                image_deletion_success = False
+                            else:
+                                print(f"Image {image_id} successfully deleted from MinIO")
+                        except Exception as e:
+                            print(f"Error checking image {image_id}: {str(e)}")
+                            image_deletion_success = False
             
             # 删除后再次搜索确认不存在
             results_after = self.indexer.find_similar_papers(
@@ -421,18 +593,25 @@ class PaperIndexerTestBed(TestBed):
             for result in results_after:
                 print(result)
             doc_exists_after = any(result.get('doc_id') == doc_id for result in results_after)
-            print(success,doc_exists_before,doc_exists_after)
-            success = success and doc_exists_before and not doc_exists_after
-            details = f"Paper {doc_id} deletion: {'successful' if success else 'failed'}"
+            print(f"Deletion status: {success}, doc_exists_before: {doc_exists_before}, doc_exists_after: {doc_exists_after}, image_deletion_success: {image_deletion_success}")
             
-            self.log_test_result("Delete Paper", success, details)
-            return {'success': success, 'details': details}
+            # 综合验证：元数据删除 + 图像删除
+            overall_success = success and doc_exists_before and not doc_exists_after and image_deletion_success
+            details = f"Paper {doc_id} deletion: {'successful' if overall_success else 'failed'}"
+            if not image_deletion_success:
+                details += " (Image deletion failed)"
+            
+            self.log_test_result("Delete Paper", overall_success, details)
+            return {'success': overall_success, 'details': details}
             
         except Exception as e:
             self.log_test_result("Delete Paper", False, f"Error: {str(e)}")
             return {'success': False, 'error': str(e)}
     
     def _test_save_and_get_blog(self) -> Dict[str, Any]:
+        print("\n" + "="*60)
+        print("🧪 TEST: _test_save_and_get_blog - 测试保存和获取博客")
+        print("="*60)
         """测试保存和获取博客"""
         try:
             # 注意：PaperIndexer中没有save_blog和get_blog方法
@@ -452,6 +631,9 @@ class PaperIndexerTestBed(TestBed):
             return {'success': False, 'error': str(e)}
     
     def _test_filtering_functionality(self) -> Dict[str, Any]:
+        print("\n" + "="*60)
+        print("🧪 TEST: _test_filtering_functionality - 测试过滤功能")
+        print("="*60)
         """测试过滤功能"""
         try:
             query = "large language models"
@@ -492,6 +674,9 @@ class PaperIndexerTestBed(TestBed):
             return {'success': False, 'error': str(e)}
     
     def _test_vector_search_with_exclusion_filter(self) -> Dict[str, Any]:
+        print("\n" + "="*60)
+        print("🧪 TEST: _test_vector_search_with_exclusion_filter - 测试向量搜索的排除过滤器功能")
+        print("="*60)
         """测试向量搜索的排除过滤器功能"""
         try:
             query = "transformer models"
@@ -593,6 +778,9 @@ class PaperIndexerTestBed(TestBed):
             return {'success': False, 'error': str(e)}
     
     def _test_full_text_storage_and_retrieval(self) -> Dict[str, Any]:
+        print("\n" + "="*60)
+        print("🧪 TEST: _test_full_text_storage_and_retrieval - 测试全文存储和检索")
+        print("="*60)
         """测试全文存储和检索"""
         try:
             doc_id = "2106.14835"
@@ -623,7 +811,9 @@ class PaperIndexerTestBed(TestBed):
             return {'success': False, 'error': str(e)}
     
     def _test_full_text_deletion(self) -> Dict[str, Any]:
-        """测试全文删除"""
+        print("\n" + "="*60)
+        print("🧪 TEST: _test_full_text_deletion - 测试全文删除")
+        print("="*60)
         try:
             doc_id = "2106.14836"
             
@@ -670,6 +860,9 @@ class PaperIndexerTestBed(TestBed):
             return {'success': False, 'error': str(e)}
     
     def _test_full_text_integration_with_search(self) -> Dict[str, Any]:
+        print("\n" + "="*60)
+        print("🧪 TEST: _test_full_text_integration_with_search - 测试全文与搜索的集成")
+        print("="*60)
         """测试全文与搜索的集成"""
         try:
             query = "NLP"
@@ -692,8 +885,381 @@ class PaperIndexerTestBed(TestBed):
             self.log_test_result("Full Text Integration with Search", False, f"Error: {str(e)}")
             return {'success': False, 'error': str(e)}
 
+    def _test_store_images(self) -> Dict[str, Any]:
+        """测试图片存储功能"""
+        print("\n" + "="*60)
+        print("🧪 TEST: _test_store_images - 测试图片存储功能")
+        print("="*60)
+        try:
+            if self.image_db is None:
+                success = True  # Skip test if image database not available
+                details = "Image database not available - test skipped"
+                self.log_test_result("Store Images", success, details)
+                return {'success': success, 'details': details}
+            
+            # 测试存储图片
+            doc_id = "2106.14834"  # 第一个测试论文，有图片
+            test_paper = None
+            for paper in self.test_papers:
+                if paper.doc_id == doc_id:
+                    test_paper = paper
+                    break
+            
+            if not test_paper or not test_paper.figure_chunks:
+                success = False
+                details = f"No figure chunks found for doc {doc_id}"
+                self.log_test_result("Store Images", success, details)
+                return {'success': success, 'details': details}
+            
+            # 清理之前的测试数据
+            print("🧹 清理之前的测试数据...")
+            image_ids = [f"{doc_id}_{chunk.id}" for chunk in test_paper.figure_chunks]
+            for image_id in image_ids:
+                self.indexer.image_db.delete_image(image_id)
+            
+            # 存储图片（默认删除临时文件）
+            indexing_status = {doc_id: {"images": False}}
+            self.indexer.store_images([test_paper], indexing_status, keep_temp_image=False)
+            
+            # 检查存储结果
+            storage_success = indexing_status[doc_id]["images"]
+            
+            # 验证存储状态在数据库中的记录
+            storage_status = self.indexer.get_image_storage_status_for_doc(doc_id)
+            expected_figure_ids = [chunk.id for chunk in test_paper.figure_chunks]
+            
+            # 验证所有图片的存储状态都为True
+            all_stored = True
+            for figure_id in expected_figure_ids:
+                image_key = f"{doc_id}_{figure_id}"
+                if not storage_status.get(image_key, False):
+                    all_stored = False
+                    break
+            
+            # 验证存储状态记录的数量正确
+            status_count_correct = len(storage_status) == len(expected_figure_ids)
+
+            
+            # 验证临时文件已被删除
+            temp_files_deleted = True
+            for chunk in test_paper.figure_chunks:
+                if chunk.image_path and os.path.exists(chunk.image_path):
+                    temp_files_deleted = False
+                    break
+            
+            success = storage_success and all_stored and status_count_correct and temp_files_deleted
+            details = f"Stored {len(test_paper.figure_chunks)} images for doc {doc_id}: {'successful' if success else 'failed'}. Storage status: {storage_status}. Temp files deleted: {temp_files_deleted}"
+            
+            self.log_test_result("Store Images", success, details)
+            return {'success': success, 'images_count': len(test_paper.figure_chunks), 'storage_status': storage_status, 'temp_files_deleted': temp_files_deleted, 'details': details}
+            
+        except Exception as e:
+            self.log_test_result("Store Images", False, f"Error: {str(e)}")
+            return {'success': False, 'error': str(e)}
+
+    def _test_list_images(self) -> Dict[str, Any]:
+        """测试列出文档图像ID功能"""
+        print("\n" + "="*60)
+        print("🧪 TEST: _test_list_images - 测试列出文档图像ID功能")
+        print("="*60)
+        try:
+            if self.image_db is None or self.metadata_db is None:
+                success = True  # Skip test if databases not available
+                details = "Image or metadata database not available - test skipped"
+                self.log_test_result("List Images", success, details)
+                return {'success': success, 'details': details}
+            
+            # 使用第二个测试文档
+            doc_id = "2106.14835"
+            test_paper = None
+            for paper in self.test_papers:
+                if paper.doc_id == doc_id:
+                    test_paper = paper
+                    break
+            
+            if not test_paper or not test_paper.figure_chunks:
+                success = False
+                details = f"No figure chunks found for doc {doc_id}"
+                self.log_test_result("List Images", success, details)
+                return {'success': success, 'details': details}
+            
+            # 清理之前的测试数据
+            print("🧹 清理之前的测试数据...")
+            image_ids = [f"{doc_id}_{chunk.id}" for chunk in test_paper.figure_chunks]
+            for image_id in image_ids:
+                self.indexer.image_db.delete_image(image_id)
+            
+            # 先存储图像
+            indexing_status = {doc_id: {"images": False}}
+            self.indexer.store_images([test_paper], indexing_status, keep_temp_image=True)
+            
+            if not indexing_status[doc_id]["images"]:
+                success = False
+                details = f"Failed to store images for doc {doc_id}"
+                self.log_test_result("List Images", success, details)
+                return {'success': success, 'details': details}
+            
+            # 测试列出图像ID
+            image_ids = self.indexer._list_image_ids(doc_id)
+            expected_count = len(test_paper.figure_chunks)
+            
+            if len(image_ids) != expected_count:
+                success = False
+                details = f"Expected {expected_count} images, but got {len(image_ids)} for doc {doc_id}"
+                self.log_test_result("List Images", success, details)
+                return {'success': success, 'details': details}
+            
+            # 验证图像ID格式正确（应该是doc_id + '_' + figure_id的格式）
+            for image_id in image_ids:
+                if not image_id.startswith(doc_id + "_"):
+                    success = False
+                    details = f"Invalid image ID format: {image_id}"
+                    self.log_test_result("List Images", success, details)
+                    return {'success': success, 'details': details}
+            
+            # 测试存储状态查询功能
+            storage_status = self.indexer.get_image_storage_status_for_doc(doc_id)
+            expected_figure_ids = [chunk.id for chunk in test_paper.figure_chunks]
+            
+            # 验证存储状态记录的数量和内容
+            status_count_correct = len(storage_status) == len(expected_figure_ids)
+            all_stored = all(storage_status.get(f"{doc_id}_{figure_id}", False) for figure_id in expected_figure_ids)
+            
+            if not status_count_correct or not all_stored:
+                success = False
+                details = f"Storage status mismatch: {storage_status}"
+                self.log_test_result("List Images", success, details)
+                return {'success': success, 'details': details}
+            
+            success = True
+            details = f"Successfully listed {len(image_ids)} images for doc {doc_id}. Storage status: {storage_status}"
+            
+            self.log_test_result("List Images", success, details)
+            return {'success': success, 'images_count': len(image_ids), 'storage_status': storage_status, 'details': details}
+            
+        except Exception as e:
+            self.log_test_result("List Images", False, f"Error: {str(e)}")
+            return {'success': False, 'error': str(e)}
+
+    def _test_delete_images_by_doc_id(self) -> Dict[str, Any]:
+        """测试批量删除文档所有图像功能"""
+        print("\n" + "="*60)
+        print("🧪 TEST: _test_delete_images_by_doc_id - 测试批量删除文档所有图像功能")
+        print("="*60)
+        try:
+            if self.image_db is None or self.metadata_db is None:
+                success = True  # Skip test if databases not available
+                details = "Image or metadata database not available - test skipped"
+                self.log_test_result("Delete Images by Doc ID", success, details)
+                return {'success': success, 'details': details}
+            
+            # 使用第四个测试文档（有图片，专门用于删除测试）
+            doc_id = "2106.14837"
+            test_paper = None
+            for paper in self.test_papers:
+                if paper.doc_id == doc_id:
+                    test_paper = paper
+                    break
+
+            if not test_paper or not test_paper.figure_chunks:
+                success = False
+                details = f"No figure chunks found for doc {doc_id}"
+                self.log_test_result("Delete Images by Doc ID", success, details)
+                return {'success': success, 'details': details}
+            
+            # 清理之前的测试数据
+            print("🧹 清理之前的测试数据...")
+            image_ids = [f"{doc_id}_{chunk.id}" for chunk in test_paper.figure_chunks]
+            for image_id in image_ids:
+                self.indexer.image_db.delete_image(image_id)
+            
+            # 先存储图像
+            indexing_status = {doc_id: {"images": False}}
+            self.indexer.store_images([test_paper], indexing_status, keep_temp_image=True)
+            
+            if not indexing_status[doc_id]["images"]:
+                success = False
+                details = f"Failed to store images for doc {doc_id} before batch deletion test"
+                self.log_test_result("Delete Images by Doc ID", success, details)
+                return {'success': success, 'details': details}
+            
+            # 获取删除前的图像列表
+            image_ids_before = self.indexer._list_image_ids(doc_id)
+            if not image_ids_before:
+                success = False
+                details = f"No images found for doc {doc_id} after storage"
+                self.log_test_result("Delete Images by Doc ID", success, details)
+                return {'success': success, 'details': details}
+            
+            expected_count = len(image_ids_before)
+            
+            # 批量删除所有图像
+            delete_result = self.indexer._delete_images_by_doc_id(doc_id)
+            if not delete_result:
+                success = False
+                details = f"Failed to delete images for doc {doc_id}"
+                self.log_test_result("Delete Images by Doc ID", success, details)
+                return {'success': success, 'details': details}
+            
+            # 验证所有图像都已被删除
+            image_ids_after = self.indexer._list_image_ids(doc_id)
+            if len(image_ids_after) != 0:
+                success = False
+                details = f"Expected 0 images after batch deletion, but got {len(image_ids_after)}"
+                self.log_test_result("Delete Images by Doc ID", success, details)
+                return {'success': success, 'details': details}
+            
+            # 验证存储状态已更新为False
+            storage_status_after = self.indexer.get_image_storage_status_for_doc(doc_id)
+            expected_figure_ids = [chunk.id for chunk in test_paper.figure_chunks]
+            
+            # 验证所有图片的存储状态都为False
+            all_deleted = all(not storage_status_after.get(f"{doc_id}_{figure_id}", True) for figure_id in expected_figure_ids)
+            
+            if not all_deleted:
+                success = False
+                details = f"Storage status not updated to False after deletion: {storage_status_after}"
+                self.log_test_result("Delete Images by Doc ID", success, details)
+                return {'success': success, 'details': details}
+            
+            success = True
+            details = f"Successfully deleted {expected_count} images for doc {doc_id}. Storage status updated: {storage_status_after}"
+            
+            self.log_test_result("Delete Images by Doc ID", success, details)
+            return {'success': success, 'deleted_count': expected_count, 'storage_status_after': storage_status_after, 'details': details}
+            
+        except Exception as e:
+            self.log_test_result("Delete Images by Doc ID", False, f"Error: {str(e)}")
+            return {'success': False, 'error': str(e)}
+
+    def _test_store_duplicated_images(self) -> Dict[str, Any]:
+        """测试重复存储图片功能"""
+        print("\n" + "="*60)
+        print("🧪 TEST: _test_store_duplicated_images - 测试重复存储图片功能")
+        print("="*60)
+        try:
+            if self.image_db is None or self.metadata_db is None:
+                success = True  # Skip test if databases not available
+                details = "Image or metadata database not available - test skipped"
+                self.log_test_result("Store Duplicated Images", success, details)
+                return {'success': success, 'details': details}
+            
+            # 使用2106.14839文档（新创建的文档，有图片）
+            doc_id = "2106.14839"
+            test_paper = None
+            for paper in self.test_papers:
+                if paper.doc_id == doc_id:
+                    test_paper = paper
+                    break
+            
+            if not test_paper or not test_paper.figure_chunks:
+                success = False
+                details = f"No figure chunks found for doc {doc_id}"
+                self.log_test_result("Store Duplicated Images", success, details)
+                return {'success': success, 'details': details}
+            
+            #检查metadata数据库中文件储存状态
+            metadata_status = self.indexer.get_paper_metadata(doc_id)
+            if metadata_status is None:
+                success = False
+                details = f"Metadata not found for doc {doc_id}"
+                self.log_test_result("Store Duplicated Images", success, details)
+                return {'success': success, 'details': details}
+            metadata_status = metadata_status.get("image_storage", {})
+            
+            # 清理之前的测试数据
+            print("🧹 清理之前的测试数据...")
+            image_ids = [f"{doc_id}_{chunk.id}" for chunk in test_paper.figure_chunks]
+            for image_id in image_ids:
+                self.indexer.image_db.delete_image(image_id)
+            
+            # 第一次存储图片（keep_temp_image=True）
+            print("📸 第一次存储图片...")
+            indexing_status_1 = {doc_id: {"images": False}}
+            self.indexer.store_images([test_paper], indexing_status_1, keep_temp_image=True)
+            
+            # 检查第一次存储结果
+            storage_success_1 = indexing_status_1[doc_id]["images"]
+            storage_status_1 = self.indexer.get_image_storage_status_for_doc(doc_id)
+            expected_figure_ids = [chunk.id for chunk in test_paper.figure_chunks]
+            
+            # 验证第一次存储状态
+            all_stored_1 = all(storage_status_1.get(f"{doc_id}_{figure_id}", False) for figure_id in expected_figure_ids)
+            
+            if not storage_success_1 or not all_stored_1:
+                success = False
+                details = f"First storage failed: storage_success={storage_success_1}, all_stored={all_stored_1}, status={storage_status_1}"
+                self.log_test_result("Store Duplicated Images", success, details)
+                return {'success': success, 'details': details}
+            
+            print(f"✓ 第一次存储成功: {storage_status_1}")
+            
+            # 第二次存储相同图片（重复存储）
+            print("📸 第二次存储相同图片（重复存储）...")
+            indexing_status_2 = {doc_id: {"images": False}}
+            self.indexer.store_images([test_paper], indexing_status_2, keep_temp_image=True)
+            
+            # 检查第二次存储结果
+            storage_success_2 = indexing_status_2[doc_id]["images"]
+            storage_status_2 = self.indexer.get_image_storage_status_for_doc(doc_id)
+            
+            # 验证第二次存储状态（应该仍然为True）
+            all_stored_2 = all(storage_status_2.get(f"{doc_id}_{figure_id}", False) for figure_id in expected_figure_ids)
+            
+            if not storage_success_2 or not all_stored_2:
+                success = False
+                details = f"Second storage failed: storage_success={storage_success_2}, all_stored={all_stored_2}, status={storage_status_2}"
+                self.log_test_result("Store Duplicated Images", success, details)
+                return {'success': success, 'details': details}
+            
+            print(f"✓ 第二次存储成功: {storage_status_2}")
+            
+            # 验证两次存储状态一致
+            if storage_status_1 != storage_status_2:
+                success = False
+                details = f"Storage status inconsistent: first={storage_status_1}, second={storage_status_2}"
+                self.log_test_result("Store Duplicated Images", success, details)
+                return {'success': success, 'details': details}
+            
+            print("✓ 存储状态一致")
+            
+            # 测试删除图片
+            print("🗑️ 测试删除图片...")
+            for figure_id in expected_figure_ids:
+                image_id = f"{doc_id}_{figure_id}"
+                delete_result = self.indexer._delete_image(image_id)
+                if not delete_result:
+                    success = False
+                    details = f"Failed to delete image {image_id}"
+                    self.log_test_result("Store Duplicated Images", success, details)
+                    return {'success': success, 'details': details}
+            
+            # 检查删除后的状态
+            storage_status_after_delete = self.indexer.get_image_storage_status_for_doc(doc_id)
+            all_deleted = all(not storage_status_after_delete.get(f"{doc_id}_{figure_id}", True) for figure_id in expected_figure_ids)
+            
+            if not all_deleted:
+                success = False
+                details = f"Images not properly deleted: {storage_status_after_delete}"
+                self.log_test_result("Store Duplicated Images", success, details)
+                return {'success': success, 'details': details}
+            
+            print(f"✓ 删除成功: {storage_status_after_delete}")
+            
+            success = True
+            details = f"Duplicate image storage test passed: first storage ({storage_status_1}), second storage ({storage_status_2}), after deletion ({storage_status_after_delete})"
+            
+            self.log_test_result("Store Duplicated Images", success, details)
+            return {'success': success, 'first_storage_status': storage_status_1, 'second_storage_status': storage_status_2, 'after_deletion_status': storage_status_after_delete, 'details': details}
+            
+        except Exception as e:
+            self.log_test_result("Store Duplicated Images", False, f"Error: {str(e)}")
+            return {'success': False, 'error': str(e)}
 
 
+
+
+# python3 -m test.index.paper_indexer_testbed
 
 if __name__ == '__main__':
     config_path = Path("/data3/guofang/AIgnite-Solutions/AIgnite/test/configs/paper_indexer_testbed_config.yaml")
@@ -706,4 +1272,5 @@ if __name__ == '__main__':
     # 创建并运行测试床
     logger.info("Initializing PaperIndexer TestBed...")
     testbed = PaperIndexerTestBed(str(config_path))
+    #print(testbed.config)
     testbed.execute()           # 这会调用 check_environment(), 创建 temp_dir, load_data(), initialize_databases(), run_tests()


### PR DESCRIPTION
Modify image_db to support save, get, and delete; modify metadata_db to support update_image_storage_status and get_image_storage_status_for_doc; For paperindexer, besides supporting save_image during indexing, we also support a separate image storage process, which works when metadata is stored before.